### PR TITLE
Terraform update

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,29 +21,9 @@ In order to install Triton, first you must have a [Triton account](https://sso.j
 1.  Get into the Triton environment with `eval $(triton env <profile name>)`.
 1.  Run `triton info` to test your configuration.
 
-#### Install Terraform
+#### Terraform
 
-[Download Terraform](https://www.terraform.io/downloads.html) and unzip the package.
-Terraform runs as a single binary named terraform. The final step is to make sure that the terraform binary is available on the PATH. See [this](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux) page for instructions on setting the PATH on Linux and Mac.
-
-Test your installation by running `terraform`. You should see an output similar to:
-
-```
-$ terraform
-Usage: terraform [--version] [--help] <command> [args]
-
-The available commands for execution are listed below.
-The most common, useful commands are shown first, followed by
-less common or more advanced commands. If you're just getting
-started with Terraform, stick with the common commands. For the
-other commands, please read the help and docs before usage.
-
-Common commands:
-    apply              Builds or changes infrastructure
-    console            Interactive console for Terraform interpolations
-
-# ...
-```
+Terraform will be downloaded automatically under the `<k8s-triton-supervisor>/bin/` directory.
 
 #### Install Ansible
 
@@ -100,8 +80,8 @@ Download the k8sontriton package and run `setup.sh`:
 
 ```bash
 $ git clone https://github.com/joyent/k8s-triton-supervisor.git
-Cloning into 'tritonK8ssupervisor'...
-$ cd tritonK8ssupervisor 
+Cloning into 'k8s-triton-supervisor'...
+$ cd k8s-triton-supervisor 
 $ ./setup.sh
 ```
 
@@ -122,9 +102,10 @@ What networks should the nodes be a part of, provide comma separated values: (31
 What KVM package should the master and nodes run on: (14b6fade-d0f8-11e5-85c5-4ff7918ab5c1)
 ```
 
-After verification of the entries, setup will provide a Kubernetes environment on triton that will be set up as below (if HA isn't set up):
+After verification of the entries, setup will provide a Kubernetes environment on triton that will be set up as below:
 
-![1x2 architecture](docs/img/1x2-arch.png)
-
+| without HA  | with HA  |
+|----|----|
+| ![1x2 architecture](docs/img/1x2-arch.png) | ![1x2 architecture](docs/img/20170530a-Triton-Kubernetes-HA.jpg) |
 
 For a more detailed guide and how the automation works, click [here](docs/detailed.md).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 In this guide, we will start a simple 2 worker node Kubernetes install that runs on Joyent Cloud.
 
 ### Pre-Reqs
-In order to start running Triton K8s Supervisor, you must create a **Triton** account and install the **Triton CLI**, **Terraform**, **Ansible**, and the **Kubernetes CLI**.
+In order to start running Triton K8s Supervisor, you must create a **Triton** account and install the **Triton CLI**, **Ansible**, and the **Kubernetes CLI**.
 
 [Triton](https://www.joyent.com/why) is our container-native and open source cloud, which we will use to provide the infrastructure required for your Kubernetes cluster. 
 

--- a/docs/detailed.md
+++ b/docs/detailed.md
@@ -18,7 +18,7 @@ Follow along as through these three easy steps in detail below.  Complete them o
 
 ### Let’s get started: the pre-requisites
 
-In order to start running Triton K8s Supervisor, you must create a **Triton** account and install the **Triton CLI**, **Terraform**, **Ansible**, and the **Kubernetes CLI**.
+In order to start running Triton K8s Supervisor, you must create a **Triton** account and install the **Triton CLI**, **Ansible**, and the **Kubernetes CLI**.
 
 [Triton](https://www.joyent.com/why) is our container-native and open source cloud, which we will use to provide the infrastructure required for your Kubernetes cluster. 
 
@@ -93,7 +93,7 @@ curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s htt
 
 ### Now let's create a Kubernetes Cluster
 
-The Triton K8s Supervisor uses `triton`, `terraform`, and `ansible` to set up and interact with a Kubernetes Cluster. Once those have been installed, you can download the [Triton K8s Supervisor package](https://github.com/joyent/k8s-triton-supervisor.git), start `setup.sh`, and answer the prompted questions.
+The Triton K8s Supervisor uses `triton`, `terraform`, and `ansible` to set up and interact with a Kubernetes Cluster. Once `triton` and `ansible` have been installed, you can download the [Triton K8s Supervisor package](https://github.com/joyent/k8s-triton-supervisor.git), start `setup.sh`, and answer the prompted questions.
 
 Default values will be shown in parentheses and if no input is provided, defaults will be used.
 

--- a/docs/detailed.md
+++ b/docs/detailed.md
@@ -37,29 +37,9 @@ In order to install Triton, first you must have a [Triton account](https://sso.j
 1.  Get into the Triton environment with `eval $(triton env <profile name>)`.
 1.  Run `triton info` to test your configuration.
 
-#### Install Terraform
+#### Terraform
 
-[Download Terraform](https://www.terraform.io/downloads.html) and unzip the package.
-Terraform runs as a single binary named terraform. The final step is to make sure that the terraform binary is available on the PATH. See [this](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux) page for instructions on setting the PATH on Linux and Mac.
-
-Test your installation by running `terraform`. You should see an output similar to:
-
-```
-$ terraform
-Usage: terraform [--version] [--help] <command> [args]
-
-The available commands for execution are listed below.
-The most common, useful commands are shown first, followed by
-less common or more advanced commands. If you're just getting
-started with Terraform, stick with the common commands. For the
-other commands, please read the help and docs before usage.
-
-Common commands:
-    apply              Builds or changes infrastructure
-    console            Interactive console for Terraform interpolations
-
-# ...
-```
+Terraform will be downloaded automatically under the `<k8s-triton-supervisor>/bin/` directory.
 
 #### Install Ansible
 

--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,48 @@ db_user=cattle
 db_pass=cattle
 
 main() {
+    if [ ! -e bin/terraform ]; then
+        echo "Getting the correct version of terraform ..."
+        # Detect the platform
+        mkdir bin
+        cd bin
+        OS="`uname`"
+        case $OS in
+            'Linux')
+                wget https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_linux_amd64.zip
+                unzip -o terraform_0.9.11_linux_amd64.zip
+                rm terraform_0.9.11_linux_amd64.zip
+                cd ..
+                ;;
+            'FreeBSD')
+                wget https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_freebsd_amd64.zip
+                unzip terraform_0.9.11_freebsd_amd64.zip
+                rm terraform_0.9.11_freebsd_amd64.zip
+                cd ..
+                ;;
+            'Darwin')
+                wget https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_darwin_amd64.zip
+                unzip terraform_0.9.11_darwin_amd64.zip
+                rm terraform_0.9.11_darwin_amd64.zip
+                cd ..
+                ;;
+            'SunOS')
+                wget https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_solaris_amd64.zip
+                unzip terraform_0.9.11_solaris_amd64.zip
+                rm terraform_0.9.11_solaris_amd64.zip
+                cd ..
+                ;;
+            *)
+                cd ..
+                echo "Couldn't determine os type."
+                exit 1
+                ;;
+        esac
+        echo ""
+        echo "Terraform for $OS added to $(pwd)/bin/ directory."
+        echo ""
+    fi
+    
     if [[ ! -z "$1" && "$1" == "-c" ]]; then
         cleanRunner
         exit 0
@@ -210,8 +252,9 @@ runTerraformTasks() {
         fi
         cd terraform
         echo "Starting terraform tasks"
-        terraform get
-        terraform apply
+        # terraform init --plugin-dir=$GOBIN
+        ../bin/terraform get
+        ../bin/terraform apply
         echo "    terraform tasks completed"
         cd ..
     fi
@@ -629,7 +672,7 @@ cleanRunner() {
                 if [ -e terraform/rancher.tf ]; then
                     cd terraform
                     echo "    destroying images..."
-                    terraform destroy -force 2> /dev/null || true
+                    ../bin/terraform destroy -force 2> /dev/null || true
                     cd ..
                 fi
                 if [[ -e terraform/hosts.ip  &&  -e terraform/masters.ip  &&  -e ~/.ssh/known_hosts ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -8,8 +8,10 @@ db_name=cattle
 db_user=cattle
 db_pass=cattle
 
+TERRAFORM=$(pwd)/bin/terraform
+
 main() {
-    if [ ! -e bin/terraform ]; then
+    if [ ! -e $TERRAFORM ]; then
         echo "Getting the correct version of terraform ..."
         # Detect the platform
         mkdir bin
@@ -253,8 +255,8 @@ runTerraformTasks() {
         cd terraform
         echo "Starting terraform tasks"
         # terraform init --plugin-dir=$GOBIN
-        ../bin/terraform get
-        ../bin/terraform apply
+        $TERRAFORM get
+        $TERRAFORM apply
         echo "    terraform tasks completed"
         cd ..
     fi
@@ -672,7 +674,7 @@ cleanRunner() {
                 if [ -e terraform/rancher.tf ]; then
                     cd terraform
                     echo "    destroying images..."
-                    ../bin/terraform destroy -force 2> /dev/null || true
+                    $TERRAFORM destroy -force 2> /dev/null || true
                     cd ..
                 fi
                 if [[ -e terraform/hosts.ip  &&  -e terraform/masters.ip  &&  -e ~/.ssh/known_hosts ]]; then


### PR DESCRIPTION
*   `setup.sh` will download terraform v0.9.11 for the appropriate OS and use that instead of requiring one in user's `PATH`.
    *   If terraform is already installed with triton provider in users path, variable `TERRAFORM` can be modified in `setup.sh` to use the installed terraform instead.
*   Documentation has been updated to reflect the change (no terraform installation required).