### PR TITLE
override fqdn to make sure hostname is <64 characters

### DIFF
--- a/terraform/modules/azure-rancher-k8s/files/install_rancher_agent.sh.tpl
+++ b/terraform/modules/azure-rancher-k8s/files/install_rancher_agent.sh.tpl
@@ -13,6 +13,7 @@ sudo curl ${docker_engine_install_url} | sh
 sudo service docker restart
 
 sudo hostnamectl set-hostname ${hostname}
+sudo bash -c 'echo "127.0.0.1 ${hostname}" >> /etc/hosts'
 
 # Run Rancher agent container
 ${rancher_agent_command}


### PR DESCRIPTION
The azure nodes where failing to register with k8s because the default search domain in azure is quite large `*********.xx.internal.cloudapp.net`. This plus the host name e.g. `azure-example-etcd-1` caused the fqdn to be >64 characters.