### PR TITLE
Fixed Script Name in Error Message

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -10,6 +10,8 @@ db_pass=cattle
 
 TERRAFORM=$(pwd)/bin/terraform
 
+MYNAME=$0
+
 main() {
     if [ ! -e $TERRAFORM ]; then
         echo "Getting the correct version of terraform ..."
@@ -61,7 +63,7 @@ main() {
 
     if [ -e terraform/rancher.tf ]; then
         echo "error: configuration for a previous run has been found"
-        echo "    clean the configuration (./setup -c)"
+        echo "    clean the configuration ($MYNAME -c)"
         exit
     fi
 


### PR DESCRIPTION
Hi,

Quick adjustment - nab the scriptname with $0, and then use it in the error message. Original message said "./setup -c" and the script was named setup.sh. 

Jay
